### PR TITLE
Implement keep and sort options for purging old release directories

### DIFF
--- a/tidy
+++ b/tidy
@@ -85,6 +85,18 @@ options:
             - Tidy files whose size is equal to or greater than the specified size. 
               Unqualified values are in bytes, but b, k, m, g, and t can be appended to specify bytes, kilobytes, megabytes, gigabytes, and terabytes, respectively. 
               Size is not evaluated for directories.
+    keep:
+        required: false
+        default: "0"
+        description:
+            - Keeps a certain number of files and directories after other filters have been applied.
+              The files kept are based on the sort order.
+    sort:
+        required: false
+        default: "name"
+        choices: [ "name", "mtime", "atime", "ctime" ]
+        description:
+            - Set the mechanism used to sort files when determining which ones to keep.
     timestamp:
         required: false
         default: "atime"
@@ -106,6 +118,9 @@ EXAMPLES = '''
 
 # Delete on /var/log files equal or greater than 10 megabytes ending with .log or .log.gz
 - tidy: path="/var/tmp" matches="*.log","*.log.gz" size="10m"
+
+# Purge all but the five latest releases based on lexicographically sorted release numbers
+- tidy: path="/opt/product" matches="release-*" keep="5" rmdirs=yes force=yes
 '''
 
 
@@ -132,7 +147,11 @@ def sizefilter(path, size=0):
         return True
     return False
 
-                        
+def filesort(path, attribute):
+    if attribute == 'name':
+        return path
+    return os.stat(path).__getattribute__("st_%s" % attribute)
+
 def main():
     module = AnsibleModule(
             argument_spec   = dict(
@@ -144,7 +163,9 @@ def main():
                 rmdirs      = dict(default='no', type='bool'),
                 size        = dict(default=0, type='str'),
                 timestamp   = dict(default="atime", choices=['atime','mtime','ctime'], type='str'),
-                silent      = dict(default='no', type='bool')
+                silent      = dict(default='no', type='bool'),
+                keep        = dict(default=0, type='int'),
+                sort        = dict(default='name', choices=['name', 'mtime', 'atime', 'ctime'], type='str')
             ),
             supports_check_mode = True
     )
@@ -192,8 +213,12 @@ def main():
         if pfilter(fsobj, params['matches']) and agefilter(fsname, age, params['timestamp']) and sizefilter(fsname, size):
             files_to_delete.append(fsname)
     
-    files_to_delete.sort()
-    dirs_to_delete.sort(reverse=not params['force'])
+    files_to_delete.sort(key=lambda x: filesort(x, params['sort']))
+    dirs_to_delete.sort(reverse=not params['force'], key=lambda x: filesort(x, params['sort']))
+    
+    if params['keep'] > 0:
+        del files_to_delete[-params['keep']:]
+        del dirs_to_delete[-params['keep']:]
     
     if module.check_mode == True:
         if len(files_to_delete) > 0 or len(dirs_to_delete) > 0:

--- a/tidy
+++ b/tidy
@@ -149,7 +149,9 @@ def sizefilter(path, size=0):
 
 def filesort(path, attribute):
     if attribute == 'name':
-        return path
+        convert = lambda text: int(text) if text.isdigit() else text
+        alphanum_key = lambda key: [ convert(c) for c in re.split('([0-9]+)', key) ]
+        return alphanum_key(path)
     return os.stat(path).__getattribute__("st_%s" % attribute)
 
 def main():


### PR DESCRIPTION
Thanks for the module @rmarchei. I needed a task that would purge old release directories after a new version, but still keep some around in case I need to rollback. I added a couple of new options to your module to do this.
